### PR TITLE
Typo fix on infrastructure page

### DIFF
--- a/infrastructure.html
+++ b/infrastructure.html
@@ -32,7 +32,7 @@ header_class: header-top
       </div>
       <div class="row">
         <div class="item feature-desc google-desc col-md-10 col-md-offset-1 col-sm-12 col-xs-12">
-          <p>Pritunl is designed to have high availability with redunant systems that have automatic failover when an instance fails. All servers are equal with no master server and can run independently in the event of other instances failing.</p>
+          <p>Pritunl is designed to have high availability with redundant systems that have automatic failover when an instance fails. All servers are equal with no master server and can run independently in the event of other instances failing.</p>
           <a class="title btn btn-lg scrollto" href="https://medium.com/@pritunl/pritunl-20k-clients-e990a399e954" target="_blank">20k Clients Test <i class="fa fa-rocket"></i></a>
         </div>
       </div>


### PR DESCRIPTION
s/redunant/redundant/
